### PR TITLE
Fix 1 excessive dependency in Makefile.in and Makefile.am reported by…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,4 @@
+
 ## $Id$
 
 include $(top_srcdir)/Makefile.am.global
@@ -45,7 +46,7 @@ test: testcase.mp3 testcase.new.mp3
 	@echo "assumptions about what this number means. You do not need to care about it."
 	@cmp -l testcase.new.mp3 $(top_srcdir)/testcase.mp3 | wc -l
 
-testupdate: testcase.mp3 testcase.new.mp3
+testupdate: testcase.new.mp3
 	cp testcase.new.mp3 $(top_srcdir)/testcase.mp3
 
 testg: frontend/mp3x$(EXEEXT) $(top_srcdir)/../test/castanets.wav

--- a/Makefile.in
+++ b/Makefile.in
@@ -884,7 +884,7 @@ test: testcase.mp3 testcase.new.mp3
 	@echo "assumptions about what this number means. You do not need to care about it."
 	@cmp -l testcase.new.mp3 $(top_srcdir)/testcase.mp3 | wc -l
 
-testupdate: testcase.mp3 testcase.new.mp3
+testupdate: testcase.new.mp3
 	cp testcase.new.mp3 $(top_srcdir)/testcase.mp3
 
 testg: frontend/mp3x$(EXEEXT) $(top_srcdir)/../test/castanets.wav


### PR DESCRIPTION
Hi, I've fixed one dependency excessive reported.
This issue can cause the unnecessary rebuild of the target "testupdate".
I've tested it on my computer, the fixed version worked as expected.

Thanks
Vemake